### PR TITLE
Multiple nodes per machine

### DIFF
--- a/discovery/.cargo/config.toml
+++ b/discovery/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -7,12 +7,16 @@ edition = "2018"
 
 [dependencies]
 rand = {version = "0.8", features = ["small_rng"]}
-tokio = {version = "1", features=["time", "net", "macros", "rt"]}
+tokio = {version = "1", features=["time", "net", "macros", "rt", "tracing"]}
 futures = "0.3"
 dashmap = "4"
-tracing = {git = "https://github.com/tokio-rs/tracing", rev = "1c73db2973b83e46c13f0ab426d80c442ebacc34" }
-tracing-futures = {git = "https://github.com/tokio-rs/tracing", rev = "1c73db2973b83e46c13f0ab426d80c442ebacc34" }
+tracing = "0.1"
+tracing-futures = "0.1"
+serde = { version = "1", features = ["derive"] }
+bincode = "1.3"
+socket2 = "0.4"
 
 [dev-dependencies]
 mac_address = "1.1.2"
-tracing-subscriber = {features = ["fmt", "ansi"], git = "https://github.com/tokio-rs/tracing", rev = "1c73db2973b83e46c13f0ab426d80c442ebacc34" }
+tracing-subscriber = {version = "0.3", features = ["fmt", "ansi", "env-filter"]}
+console-subscriber = "0.1"

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 rand = {version = "0.8", features = ["small_rng"]}
-tokio = {version = "1", features=["time", "net", "macros", "rt", "tracing", "sync"]}
+tokio = {version = "1", features=["time", "net", "macros", "rt", "tracing"]}
 futures = "0.3"
 dashmap = "4"
 tracing = "0.1"

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 rand = {version = "0.8", features = ["small_rng"]}
-tokio = {version = "1", features=["time", "net", "macros", "rt", "tracing"]}
+tokio = {version = "1", features=["time", "net", "macros", "rt", "tracing", "sync"]}
 futures = "0.3"
 dashmap = "4"
 tracing = "0.1"

--- a/discovery/examples/exchange_id.rs
+++ b/discovery/examples/exchange_id.rs
@@ -7,16 +7,16 @@ use tracing_subscriber::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    // let filter = EnvFilter::from_default_env();
-    let console_layer = console_subscriber::spawn();
-    // let fmt_layer = fmt::layer()
-    //     .with_target(false)
-    //     .pretty();
+    let filter = EnvFilter::from_default_env();
+    // let console_layer = console_subscriber::spawn();
+    let fmt_layer = fmt::layer()
+        .with_target(false)
+        .pretty();
 
     tracing_subscriber::registry()
-        .with(console_layer)
-        // .with(filter)
-        // .with(fmt_layer)
+        // .with(console_layer)
+        .with(filter)
+        .with(fmt_layer)
         .init();
 
     let mut args = env::args().skip(1);

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -81,9 +81,12 @@ async fn sleep_then_request_responses(sock: Arc<UdpSocket>, period: Duration, ms
 
 #[tracing::instrument]
 pub async fn maintain(sock: UdpSocket, chart: Chart) {
-    let f1 = awnser_incoming(&sock, &chart);
-    let f2 = sleep_then_request_responses(&sock, Duration::from_secs(5), chart.id);
-    futures::join!(f1, f2);
+    let sock = Arc::new(sock);
+    let msg = chart.discovery_msg();
+    let f1 = tokio::spawn(register_incoming(sock.clone(), chart));
+    let f2 = tokio::spawn(sleep_then_request_responses(sock, Duration::from_secs(5), msg));
+    let (_, _) = futures::join!(f1, f2);
+    unreachable!("never returns")
 }
 
 #[tracing::instrument]

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -173,6 +173,7 @@ pub async fn setup(id: Id, port: u16) -> (UdpSocket, Chart) {
     sock.join_multicast_v4(&multiaddr, &interface).unwrap();
 
     let sock = std::net::UdpSocket::from(sock); 
+    sock.set_nonblocking(true).unwrap();
     let sock = UdpSocket::from_std(sock).unwrap();
 
     let chart = Chart {

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -6,8 +6,6 @@ use std::time::Duration;
 use rand::{Rng, SeedableRng};
 use tokio::net::UdpSocket;
 use tokio::time::sleep;
-use tokio::time::timeout;
-use tokio::sync::Mutex;
 use tracing::info;
 use serde::{Serialize, Deserialize};
 
@@ -60,53 +58,18 @@ impl Chart {
     }
 }
 
-#[derive(Debug, Clone)]
-struct FixedUdpSocket (Arc<Mutex<UdpSocket>>);
-impl FixedUdpSocket {
-    async fn recv(&self, buf: &mut [u8]) -> Result<(usize, std::net::SocketAddr), std::io::Error> {
-        loop {
-            sleep(Duration::from_millis(250)).await;
-            let sock = self.0.lock().await;
-            dbg!("got recv lock");
-            let recv = sock.recv_from(buf);
-
-            if let Ok(res) = timeout(Duration::from_millis(250), recv).await {
-                dbg!("succesfully recvd");
-                break res;
-            }
-            dbg!("timed out recv");
-        }
-    }
-    async fn send_to(&self, buf: &[u8], addr: impl tokio::net::ToSocketAddrs) -> Result<usize, std::io::Error> {
-        dbg!("trying to send msg");
-        let sock = loop {
-            match self.0.try_lock() {
-                Ok(l) => break l,
-                Err(_) => sleep(Duration::from_millis(100)).await,
-            }
-            dbg!("stuck trying to get lock");
-        };
-        // let sock = self.0.lock().await;
-        dbg!("sending msg");
-        sock.send_to(&buf, addr).await
-    }
-}
-
-
 #[tracing::instrument]
-async fn register_incoming(sock: FixedUdpSocket, chart: Chart) {
-    let mut rng = rand::rngs::SmallRng::from_entropy();
+async fn awnser_incoming(sock: &UdpSocket, chart: &Chart) {
     let mut buf = [0; 1024];
     loop {
-        let random_sleep = rng.gen_range(Duration::from_secs(0)..Duration::from_secs(1));
-        sleep(random_sleep).await;
-        let (len, addr) = sock.recv(&mut buf).await.unwrap();
-        // chart.add_response(&buf[0..len], addr);
+        let (len, addr) = sock.recv_from(&mut buf).await.unwrap();
+        sock.send_to(&chart.id.to_ne_bytes(), addr).await.unwrap();
+        chart.add_response(&buf[0..len], addr);
     }
 }
 
 #[tracing::instrument]
-async fn sleep_then_request_responses(sock: FixedUdpSocket, period: Duration, msg: DiscoveryMsg) {
+async fn sleep_then_request_responses(sock: Arc<UdpSocket>, period: Duration, msg: DiscoveryMsg) {
     let mut rng = rand::rngs::SmallRng::from_entropy();
 
     loop {
@@ -118,7 +81,7 @@ async fn sleep_then_request_responses(sock: FixedUdpSocket, period: Duration, ms
 
 #[tracing::instrument]
 pub async fn maintain(sock: UdpSocket, chart: Chart) {
-    let sock = FixedUdpSocket (Arc::new(Mutex::new(sock)));
+    let sock = Arc::new(sock);
     let msg = chart.discovery_msg();
     let f1 = tokio::spawn(register_incoming(sock.clone(), chart));
     let f2 = tokio::spawn(sleep_then_request_responses(sock, Duration::from_secs(5), msg));
@@ -127,7 +90,8 @@ pub async fn maintain(sock: UdpSocket, chart: Chart) {
 }
 
 #[tracing::instrument]
-async fn request_respons(sock: &FixedUdpSocket, msg: DiscoveryMsg) {
+async fn request_respons(sock: &Arc<UdpSocket>, msg: DiscoveryMsg) {
+    dbg!("requesting response");
     let multiaddr = Ipv4Addr::from([224, 0, 0, 251]);
     let buf = bincode::serialize(&msg).unwrap();
     let _len = sock

--- a/makefile
+++ b/makefile
@@ -67,6 +67,9 @@ bin/bench_ls: client_examples
 # Other
 #----------------------------------------------------------------------------
 
+local:
+	bash scripts/deploy_local.sh
+
 deploy: bin/meta-server
 	$(info test done)
 	bash scripts/deploy_cluster.sh

--- a/meta-server/Cargo.toml
+++ b/meta-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 client_protocol = { package = "protocol", path = "../protocol" }
 discovery = { package = "discovery", path = "../discovery" }
 
-structopt = "0.3"
+clap = { version = "3", features = ["derive"] }
 futures = "0.3"
 gethostname = "0.2"
 rand = {version = "0.8", features = ["small_rng"]}

--- a/meta-server/Cargo.toml
+++ b/meta-server/Cargo.toml
@@ -25,10 +25,10 @@ futures-util = "0.3"
 thiserror = "1"
 
 simplelog = "0.10"
-tracing = {git = "https://github.com/tokio-rs/tracing", features = ["log-always"] }
-tracing-futures = {git = "https://github.com/tokio-rs/tracing" }
-tracing-subscriber = {git = "https://github.com/tokio-rs/tracing", features = ["fmt", "json"] }
-tracing-opentelemetry = {git = "https://github.com/tokio-rs/tracing" }
+tracing = {git = "https://github.com/tokio-rs/tracing", rev = "8d4d5ac", features = ["log-always"] }
+tracing-futures = {git = "https://github.com/tokio-rs/tracing", rev = "8d4d5ac" }
+tracing-subscriber = {git = "https://github.com/tokio-rs/tracing", rev = "8d4d5ac", features = ["fmt", "json"] }
+tracing-opentelemetry = {git = "https://github.com/tokio-rs/tracing", rev = "8d4d5ac" }
 # tracing-log = {git = "https://github.com/tokio-rs/tracing" }
 
 opentelemetry = { version = "0.16", features = ["trace", "rt-tokio"] }

--- a/meta-server/src/consensus/election.rs
+++ b/meta-server/src/consensus/election.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpStream;
 use tokio::sync::Notify;
 use tokio::time::{self, timeout_at, Duration, Instant};
 
-use tracing::{info, trace, warn};
+use tracing::{info, warn};
 
 use super::{State, HB_TIMEOUT};
 use crate::server_conn::protocol::{FromRS, ToRs};

--- a/meta-server/src/consensus/state.rs
+++ b/meta-server/src/consensus/state.rs
@@ -36,7 +36,7 @@ macro_rules! load_atomic {
 }
 
 impl State {
-    pub fn new(config: impl Into<Config>, change_idx: u64) -> Self {
+    pub fn new(config: Config, change_idx: u64) -> Self {
         Self {
             term: AtomicU64::new(0),
             change_idx: AtomicU64::new(change_idx),

--- a/meta-server/src/directory/mod.rs
+++ b/meta-server/src/directory/mod.rs
@@ -1,4 +1,4 @@
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 pub mod readserv;
 pub mod writeserv;
@@ -6,7 +6,7 @@ pub mod db;
 
 pub use db::DbError;
 
-use crate::consensus::HB_TIMEOUT;
+// use crate::consensus::HB_TIMEOUT;
 
 type ChunkId = u64;
 pub struct File {

--- a/meta-server/src/directory/mod.rs
+++ b/meta-server/src/directory/mod.rs
@@ -10,6 +10,6 @@ pub use db::DbError;
 
 type ChunkId = u64;
 pub struct File {
-    lease: Option<Instant>,
-    chunks: Vec<ChunkId>,
+    _lease: Option<Instant>,
+    _chunks: Vec<ChunkId>,
 }

--- a/meta-server/src/directory/readserv.rs
+++ b/meta-server/src/directory/readserv.rs
@@ -38,7 +38,7 @@ impl Directory {
         match change {
             Change::DirAdded(path) => self.db.mkdir(path).expect(EXPECT_STR),
             Change::DirRemoved(path) => self.db.rmdir(path).expect(EXPECT_STR),
-            Change::FileAdded(path) => todo!(),
+            Change::FileAdded(_path) => todo!(),
         }
         self.db.update(change_idx);
         self.db.flush().await;

--- a/meta-server/src/directory/writeserv.rs
+++ b/meta-server/src/directory/writeserv.rs
@@ -83,7 +83,7 @@ impl Directory {
         self.consistent_change(change, apply_to_db).await
     }
 
-    pub async fn open(&mut self, path: PathString, existance: Existence) -> Result<(), DbError> {
+    pub async fn open(&mut self, _path: PathString, _existance: Existence) -> Result<(), DbError> {
         todo!()
     }
 }

--- a/meta-server/src/main.rs
+++ b/meta-server/src/main.rs
@@ -178,7 +178,7 @@ async fn main() {
     // setup_tracing(&opt);
 
     let id = id_from_mac();
-    let (sock, chart) = discovery::setup(id, opt.control_port).await;
+    let (sock, chart) = discovery::setup(id).await;
     let (dir, change_idx) = readserv::Directory::new();
     let state = consensus::State::new(&opt, change_idx);
     let state = Arc::new(state);

--- a/meta-server/src/main.rs
+++ b/meta-server/src/main.rs
@@ -73,7 +73,7 @@ fn setup_tracing(opt: &Opt) {
         .unwrap();
 
     use tracing_subscriber::prelude::*;
-    use tracing_subscriber::{fmt, Registry};
+    use tracing_subscriber::Registry;
     let telemetry = tracing_opentelemetry::subscriber().with_tracer(tracer);
 
     let subscriber = Registry::default().with(telemetry);

--- a/meta-server/src/read_meta/mod.rs
+++ b/meta-server/src/read_meta/mod.rs
@@ -5,7 +5,6 @@ use futures_util::TryStreamExt;
 use tracing::error;
 use tracing::trace;
 use std::net::IpAddr;
-use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -70,12 +69,7 @@ async fn client_conn(mut stream: ReqStream, dir: &Directory, chart: &Chart, stat
     }
 }
 
-pub async fn meta_server(port: u16, dir: &Directory, chart: &Chart, state: &Arc<State>) {
-    let addr = (IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
-    let listener = TcpListener::bind(addr)
-        .await
-        .expect("can not listen for client meta requests");
-
+pub async fn meta_server(listener: &mut TcpListener, dir: &Directory, chart: &Chart, state: &Arc<State>) {
     loop {
         let dir = dir.clone();
         let chart = chart.clone();
@@ -127,10 +121,7 @@ async fn cmd_conn(mut stream: RsStream, source: SocketAddr, state: &State, dir: 
     }
 }
 
-pub async fn cmd_server(port: u16, state: Arc<State>, dir: &Directory) {
-    let addr = (IpAddr::V4(Ipv4Addr::UNSPECIFIED), port);
-    let listener = TcpListener::bind(addr).await.unwrap();
-
+pub async fn cmd_server(listener: TcpListener, state: Arc<State>, dir: &Directory) {
     loop {
         let state = state.clone();
         let dir = dir.clone();

--- a/meta-server/src/read_meta/mod.rs
+++ b/meta-server/src/read_meta/mod.rs
@@ -9,8 +9,6 @@ use std::net::Ipv4Addr;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tracing::info;
-use tracing::warn;
 
 use crate::consensus::State;
 use crate::directory::readserv::Directory;

--- a/scripts/bench/ls.sh
+++ b/scripts/bench/ls.sh
@@ -18,12 +18,13 @@ touch $run_numb.last_run
 client_port=50978
 nserver_nodes=4
 bin="meta-server"
-args="
-	--client-port $client_port \
+args="\
 	--cluster-size $nserver_nodes \
-	--control-port 50972 \
 	--tracing-endpoint fs1.cm.cluster \
-	--run-numb $run_numb"
+	--run-numb $run_numb \
+	deploy \
+	--client-port $client_port \
+	--control-port 50972"
 
 res=$(deploy $nserver_nodes $bin $args)
 echo $res

--- a/scripts/bench/mkdir.sh
+++ b/scripts/bench/mkdir.sh
@@ -18,12 +18,13 @@ touch $run_numb.last_run
 client_port=50978
 nserver_nodes=3
 bin="meta-server"
-args="
-	--client-port $client_port \
+args="\
 	--cluster-size $nserver_nodes \
-	--control-port 50972 \
 	--tracing-endpoint fs1.cm.cluster \
-	--run-numb $run_numb"
+	--run-numb $run_numb \
+	deploy \
+	--client-port $client_port \
+	--control-port 50972"
 
 res=$(deploy $nserver_nodes $bin $args)
 echo $res

--- a/scripts/deploy_cluster.sh
+++ b/scripts/deploy_cluster.sh
@@ -12,14 +12,15 @@ rm *.last_run >& /dev/null || true
 touch $run_numb.last_run
 
 # deploy cluster
-numb_nodes=23
+nserver_nodes=23
 bin="meta-server"
-args="
-	--client-port 50975 \
-	--cluster-size $numb_nodes \
-	--control-port 50972 \
+args="\
+	--cluster-size $nserver_nodes \
 	--tracing-endpoint fs1.cm.cluster \
-	--run-numb $run_numb"
+	--run-numb $run_numb \
+	deploy \
+	--client-port 50975 \
+	--control-port 50972"
 deploy $numb_nodes $bin $args
 attach
 cleanup

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -8,9 +8,10 @@ function window_cmd()
 {
 	local dir="$1"
 	local base_cmd="$2"
+	local id="$3"
 	# remain on exit is broken on older tmux (https://github.com/tmux/tmux/issues/1354)
 	# for now just using a long sleep to ensure the window stays open
-	echo "tmux setw remain-on-exit on; cd $dir; RUST_BACKTRACE=1 $base_cmd; sleep 99999"
+	echo "tmux setw remain-on-exit on; cd $dir; RUST_BACKTRACE=1 $base_cmd $id; sleep 99999"
 }
 
 function run_in_tmux_windows()
@@ -21,15 +22,16 @@ function run_in_tmux_windows()
 	echo base_cmd: $base_cmd
 
 	local dir=`mktemp --directory --suffix _raftfs`
-	local name="0"
-	local cmd=$(window_cmd $dir "$base_cmd")
+	local id=0
+	local cmd=$(window_cmd $dir "$base_cmd" $id)
 	echo $cmd
 	tmux new-session -s $session_name -n $name -d "${cmd}" # TODO FIXME
 	for (( i = 1; i < size; i++ )); do
-		local name="$i"
+		local id=$i
+		local name=$i
 		local dir=`mktemp --directory --suffix raft-fs`
-		local cmd=$(window_cmd $dir "$base_cmd")
-		tmux new-window -t "$session_name:$i" -n $name -d "$cmd"
+		local cmd=$(window_cmd $dir "$base_cmd" $id)
+		tmux new-window -t "$session_name" -n $name -d "$cmd"
 	done
 }
 
@@ -40,7 +42,8 @@ cargo b
 args="\
 	--cluster-size $SIZE \
 	--tracing-endpoint fs1.cm.cluster \
-	--run-numb 1"
+	--run-numb 1 \
+	local"
 
 bin=`pwd`/target/debug/meta-server
 

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -25,22 +25,20 @@ function run_in_tmux_windows()
 	local cmd=$(window_cmd $dir "$base_cmd")
 	echo $cmd
 	tmux new-session -s $session_name -n $name -d "${cmd}" # TODO FIXME
-	# for (( i = 1; i < size; i++ )); do
-	# 	local name="$i"
-	# 	local dir=`mktemp --directory --suffix raft-fs`
-	# 	local cmd=$(window_cmd $dir "$base_cmd")
-	# 	tmux new-window -t "$session_name:$i" -n $name -d "$cmd"
-	# done
+	for (( i = 1; i < size; i++ )); do
+		local name="$i"
+		local dir=`mktemp --directory --suffix raft-fs`
+		local cmd=$(window_cmd $dir "$base_cmd")
+		tmux new-window -t "$session_name:$i" -n $name -d "$cmd"
+	done
 }
 
 SIZE=3
 cd meta-server
 cargo b
 
-args="
-	--client-port 50975 \
+args="\
 	--cluster-size $SIZE \
-	--control-port 50972 \
 	--tracing-endpoint fs1.cm.cluster \
 	--run-numb 1"
 
@@ -49,11 +47,3 @@ bin=`pwd`/target/debug/meta-server
 run_in_tmux_windows $SIZE "$bin $args"
 tmux attach-session -t raftfs
 tmux kill-session -t raftfs
-
-# FIXME the following is working
-# cmd=`echo "tmux setw remain-on-exit on; cd /tmp/tmp.wE7lV9HmMz_raftfs; RUST_BACKTRACE=1 /home/work/interview/raft-fs/meta-server/target/debug/meta-server --client-port 50975 --cluster-size 3 --control-port 50972 --tracing-endpoint fs1.cm.cluster --run-numb 1; sleep 99999"`
-
-# session_name="raft"
-# name="0"
-# tmux new-session -s $session_name -n $name -d "${cmd}"
-

--- a/scripts/deploy_local.sh
+++ b/scripts/deploy_local.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# call with raft-fs root dir as working dir
+
+set -e
+
+function window_cmd()
+{
+	local dir="$1"
+	local base_cmd="$2"
+	# remain on exit is broken on older tmux (https://github.com/tmux/tmux/issues/1354)
+	# for now just using a long sleep to ensure the window stays open
+	echo "tmux setw remain-on-exit on; cd $dir; RUST_BACKTRACE=1 $base_cmd; sleep 99999"
+}
+
+function run_in_tmux_windows()
+{
+	local size="$1"
+	local base_cmd="$2"
+	local session_name=raftfs
+	echo base_cmd: $base_cmd
+
+	local dir=`mktemp --directory --suffix _raftfs`
+	local name="0"
+	local cmd=$(window_cmd $dir "$base_cmd")
+	echo $cmd
+	tmux new-session -s $session_name -n $name -d "${cmd}" # TODO FIXME
+	# for (( i = 1; i < size; i++ )); do
+	# 	local name="$i"
+	# 	local dir=`mktemp --directory --suffix raft-fs`
+	# 	local cmd=$(window_cmd $dir "$base_cmd")
+	# 	tmux new-window -t "$session_name:$i" -n $name -d "$cmd"
+	# done
+}
+
+SIZE=3
+cd meta-server
+cargo b
+
+args="
+	--client-port 50975 \
+	--cluster-size $SIZE \
+	--control-port 50972 \
+	--tracing-endpoint fs1.cm.cluster \
+	--run-numb 1"
+
+bin=`pwd`/target/debug/meta-server
+
+run_in_tmux_windows $SIZE "$bin $args"
+tmux attach-session -t raftfs
+tmux kill-session -t raftfs
+
+# FIXME the following is working
+# cmd=`echo "tmux setw remain-on-exit on; cd /tmp/tmp.wE7lV9HmMz_raftfs; RUST_BACKTRACE=1 /home/work/interview/raft-fs/meta-server/target/debug/meta-server --client-port 50975 --cluster-size 3 --control-port 50972 --tracing-endpoint fs1.cm.cluster --run-numb 1; sleep 99999"`
+
+# session_name="raft"
+# name="0"
+# tmux new-session -s $session_name -n $name -d "${cmd}"
+

--- a/scripts/tests/mkdir.sh
+++ b/scripts/tests/mkdir.sh
@@ -16,14 +16,15 @@ touch $run_numb.last_run
 
 # deploy cluster
 client_port=50978
-numb_nodes=3
+nserver_nodes=3
 bin="meta-server"
-args="
-	--client-port $client_port \
-	--cluster-size $numb_nodes \
-	--control-port 50972 \
+args="\
+	--cluster-size $nserver_nodes \
 	--tracing-endpoint fs1.cm.cluster \
-	--run-numb $run_numb"
+	--run-numb $run_numb \
+	deploy \
+	--client-port 50975 \
+	--control-port $client_port"
 
 res=$(deploy $numb_nodes $bin $args)
 echo $res


### PR DESCRIPTION
This PR will enable multiple instances of raft-fs, that is multiple nodes, to be ran on the same physical machine fixing #3 . For this the following changes:

- [x] if no port is passed to a raft-fs server instance it will pick a unique port
- [x] node discovery now shares not only the id but also the port the node is running on
- [x] multiple instances of node discovery can run on the same machine sharing the discovery port
- [x] adds a shell script to easily launch a cluster on the current host each node in a different tmux window